### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy==1.18.1
-pytest==5.3.5
-pytest-subtests==0.3.0
-TatSu==5.5.0
-lxml~=4.5.0
-setuptools~=49.3.1
-colorama~=0.4.3
-coverage==5.2.1
+numpy==1.22.4
+pytest==7.1.2
+pytest-subtests==0.8.0
+TatSu==5.6.1
+lxml==4.8.0
+setuptools>=49.3.1
+colorama==0.4.4
+coverage==6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
-numpy==1.22.4
-pytest==7.1.2
-pytest-subtests==0.8.0
-TatSu==5.6.1
-lxml==4.8.0
+.
 setuptools>=49.3.1
-colorama==0.4.4
-coverage==6.4

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ from setuptools import setup
 
 version = re.search(
     r'^__version__\s*=\s*"(.*)"',
-    open('uppyyl_simulator/uppyyl_simulator.py').read(),
-    re.M
+    open("uppyyl_simulator/uppyyl_simulator.py").read(),
+    re.M,
 ).group(1)
 
 with open("README.md", "rb") as f:
@@ -20,8 +20,8 @@ setup(
     packages=["uppyyl_simulator"],
     entry_points={
         "console_scripts": [
-            'uppyyl_simulator = uppyyl_simulator.uppyyl_simulator:main',
-            'uppyyl-simulator = uppyyl_simulator.uppyyl_simulator:main',
+            "uppyyl_simulator = uppyyl_simulator.uppyyl_simulator:main",
+            "uppyyl-simulator = uppyyl_simulator.uppyyl_simulator:main",
         ]
     },
     version=version,
@@ -30,16 +30,16 @@ setup(
     author="Sascha Lehmann",
     author_email="s.lehmann@tuhh.de",
     project_urls={
-        'Affiliation': 'https://www.tuhh.de/sts',
+        "Affiliation": "https://www.tuhh.de/sts",
     },
     url="",
     install_requires=[
-        'numpy==1.18.1',
-        'pytest==5.3.5',
-        'pytest-subtests==0.3.0',
-        'TatSu==5.5.0',
-        'lxml~=4.5.0',
-        'colorama~=0.4.3',
-        'coverage==5.2.1',
+        "numpy==1.22.4",
+        "pytest==7.1.2",
+        "pytest-subtests==0.8.0",
+        "TatSu==5.6.1",
+        "lxml==4.8.0",
+        "colorama==0.4.4",
+        "coverage==6.4",
     ],
 )


### PR DESCRIPTION
Hi, 

this PR fixes #1. It updates the dependencies to their current version, except TatSu. The problem with the current version of TatSu (5.8.0) is that there is an error occurring when running the uppyyl-simulator:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/uppyyl-simulator/uppyyl_simulator/__main__.py", line 5, in <module>
    main()
  File "/uppyyl-simulator/uppyyl_simulator/uppyyl_simulator.py", line 11, in main
    prompt = UppyylSimulatorCLI()
  File "/uppyyl-simulator/uppyyl_simulator/cli/cli.py", line 76, in __init__
    self.uppaal_simulator.load_system(system_path=init_model)
  File "/uppyyl-simulator/uppyyl_simulator/backend/simulator/simulator.py", line 146, in load_system
    self.set_system(system_xml_str)
  File "/uppyyl-simulator/uppyyl_simulator/backend/simulator/simulator.py", line 155, in set_system
    system = uppaal_xml_to_system(system)
  File "/uppyyl-simulator/uppyyl_simulator/backend/ast/parsers/uppaal_xml_model_parser.py", line 390, in uppaal_xml_to_system
    system = uppaal_dict_to_system(system_data)
  File "/uppyyl-simulator/uppyyl_simulator/backend/ast/parsers/uppaal_xml_model_parser.py", line 252, in uppaal_dict_to_system
    system.set_declaration(system_data["global_declaration"])
  File "/uppyyl-simulator/uppyyl_simulator/backend/models/base/automaton_network.py", line 103, in set_declaration
    decl = Declaration(decl)
  File "/uppyyl-simulator/uppyyl_simulator/backend/models/base/declaration.py", line 34, in __init__
    super().__init__(decl_data)
  File "/uppyyl-simulator/uppyyl_simulator/backend/data_structures/ast/ast_code_element.py", line 23, in __init__
    self.set_text(data)
  File "/uppyyl-simulator/uppyyl_simulator/backend/data_structures/ast/ast_code_element.py", line 69, in set_text
    self.update_ast()
  File "/uppyyl-simulator/uppyyl_simulator/backend/models/base/declaration.py", line 68, in update_ast
    self.ast = self.parser.parse(self.text, rule_name='UppaalDeclaration', trace=False)
  File "/usr/local/lib/python3.10/site-packages/tatsu/contexts.py", line 239, in parse
    raise self._furthest_exception
  File "/usr/local/lib/python3.10/site-packages/tatsu/contexts.py", line 231, in parse
    rule = self._find_rule(start)
  File "/usr/local/lib/python3.10/site-packages/tatsu/parsing.py", line 18, in _find_rule
    self._error(name, exclass=FailedRef)
  File "/usr/local/lib/python3.10/site-packages/tatsu/contexts.py", line 549, in _error
    raise self._make_exception(item, exclass=exclass)
tatsu.exceptions.FailedRef: (1:1) could not resolve reference to rule 'start' :
// Place global declarations here.
^
```

Apart from the upgrades, this PR makes `requirements.txt` referencing the dependencies in `setup.py`. With this, the dependencies are only needed to be specified ones.